### PR TITLE
avoid push buffer overflow 

### DIFF
--- a/app/src/main/java/com/htetznaing/adbotg/Push.java
+++ b/app/src/main/java/com/htetznaing/adbotg/Push.java
@@ -42,7 +42,7 @@ public class Push {
 
         stream.write(mode.getBytes());
 
-        byte[] buff = new byte[adbConnection.getMaxData()];
+        byte[] buff = new byte[adbConnection.getMaxData() -10 ]; //avoid overflow
         InputStream is = new FileInputStream(local);
 
         long sent = 0;


### PR DESCRIPTION
buffer overflows on large file transfer removing 10 bytes fixes the issue